### PR TITLE
override dispose to avoid exception when popping pages

### DIFF
--- a/lib/slider.dart
+++ b/lib/slider.dart
@@ -143,6 +143,12 @@ class _SquigglySliderState extends State<SquigglySlider>
   }
 
   @override
+  void dispose() {
+    phaseController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) => SliderTheme(
         data: SliderTheme.of(context).copyWith(
           trackShape: SquigglySliderTrackShape(


### PR DESCRIPTION
When popping a widget using SquigglySlider, I got an exception saying that `Ticker must be disposed before calling super.dispose()`. This can be fixed by explicitly disposing the `AnimationController` in the `dispose` function.